### PR TITLE
Inline all the things

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -263,6 +263,7 @@ struct TensorExprKernel {
     }
 
     LOG(FATAL) << "Not a constant!";
+    return Expr();
   }
 
   template <typename T>
@@ -352,6 +353,12 @@ struct TensorExprKernel {
     CHECK(tensors.count(output->unique())) << "Output must be a tensor";
     tensor_output = &tensors.at(output->unique());
     torch::jit::compiler::schedule::Schedule sch({*tensor_output});
+    for (auto& p : tensors) {
+      auto& t = p.second;
+      if (&t != tensor_output) {
+        t.ComputeInline();
+      }
+    }
     stmt = sch.Lower();
   }
 


### PR DESCRIPTION
Seems to work beautifully on our tests.py :-).  Of course this only makes sense for fusing the pointwise things, but that's the point for the time being.  We'll probably want something like TVM's AutoInlineInjective eventually.