### PR TITLE
Clean up sketchy handling of scalar args in llvm codegen

### DIFF
--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -881,10 +881,7 @@ void testLLVMDynamicShapeAdd() {
     std::vector<float> bData(size, 2.0f);
     std::vector<float> cData(size, 0.0f);
     LLVMCodeGen cg(s, {a, b, c, n});
-    // FIXME: int to pointer cast is pretty gross but this API is just for
-    // testing anyways.
-    std::vector<void*> args(
-        {aData.data(), bData.data(), cData.data(), (void*)(intptr_t)size});
+    std::vector<void*> args({aData.data(), bData.data(), cData.data(), &size});
     cg.value<float>(args);
     ExpectAllNear(cData, std::vector<float>(size, 3.0f), 1e-7);
   };

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -112,6 +112,7 @@ namespace jit {
   _(LLVMBroadcastAdd)           \
   _(LLVMDynamicShapeAdd)        \
   _(LLVMBindDynamicShapeAdd)    \
+  _(LLVMTensorDynamicShapeAdd)  \
   _(LLVMIfThenElseTest)
 
 #define TH_FORALL_TESTS_CUDA(_) \

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -121,6 +121,14 @@ class CodeGen::CallArg {
     return fval_;
   }
 
+  int* intPtr() const {
+    return const_cast<int*>(&ival_);
+  }
+
+  float* floatPtr() const {
+    return const_cast<float*>(&fval_);
+  }
+
  private:
   union {
     void* ptr_;


### PR DESCRIPTION
We were reading a field out of a union that may not have been the last-written (which is UB), and then stuffing it into a void*, even if the written value was a float.  That was all obviously terrible so this PR fixes it.