### PR TITLE
Remove IRNode. 

### DIFF
--- a/test/cpp/tensorexpr/padded_buffer.h
+++ b/test/cpp/tensorexpr/padded_buffer.h
@@ -37,6 +37,8 @@ class PaddedBufferBase {
     return total_size_ + 2 * kPaddingSize;
   }
 
+  virtual ~PaddedBufferBase() {}
+
  protected:
   explicit PaddedBufferBase(
       const std::vector<int>& dims,

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -2,6 +2,7 @@
 #include "test/cpp/tensorexpr/test_base.h"
 
 #include "test/cpp/tensorexpr/padded_buffer.h"
+#include "test/cpp/tensorexpr/test_utils.h"
 #include "torch/csrc/jit/tensorexpr/buffer.h"
 #include "torch/csrc/jit/tensorexpr/eval.h"
 #include "torch/csrc/jit/tensorexpr/function.h"
@@ -18,17 +19,19 @@ namespace jit {
 using namespace torch::jit::tensorexpr;
 using namespace torch::jit::tensorexpr::schedule;
 
+using LLVMExprEval = ExprEval<LLVMCodeGen>;
+
 void testLLVMIntImmTest() {
   KernelScope kernel_scope;
   auto a = IntImm::make(2);
-  LLVMCodeGen cg(a);
+  LLVMExprEval cg(a);
   EXPECT_EQ(cg.value<int>(), 2);
 }
 
 void testLLVMFloatImmTest() {
   KernelScope kernel_scope;
   auto a = FloatImm::make(1.0);
-  LLVMCodeGen cg(a, {}, kFloat32);
+  LLVMExprEval cg(a, {});
   EXPECT_EQ(cg.value<float>(), 1.0);
 }
 
@@ -37,7 +40,7 @@ void testLLVMIntAddTest() {
   auto a = IntImm::make(2);
   auto b = IntImm::make(3);
   auto c = Add::make(a, b);
-  LLVMCodeGen cg(c);
+  LLVMExprEval cg(c);
   EXPECT_EQ(cg.value<int>(), 5);
 }
 
@@ -46,7 +49,7 @@ void testLLVMIntSubTest() {
   auto a = IntImm::make(2);
   auto b = IntImm::make(3);
   auto c = Sub::make(a, b);
-  LLVMCodeGen cg(c);
+  LLVMExprEval cg(c);
   EXPECT_EQ(cg.value<int>(), -1);
 }
 
@@ -55,7 +58,7 @@ void testLLVMIntMulTest() {
   auto a = IntImm::make(2);
   auto b = IntImm::make(3);
   auto c = Mul::make(a, b);
-  LLVMCodeGen cg(c);
+  LLVMExprEval cg(c);
   EXPECT_EQ(cg.value<int>(), 6);
 }
 
@@ -64,7 +67,7 @@ void testLLVMIntDivTest() {
   auto a = IntImm::make(6);
   auto b = IntImm::make(3);
   auto c = Div::make(a, b);
-  LLVMCodeGen cg(c);
+  LLVMExprEval cg(c);
   EXPECT_EQ(cg.value<int>(), 2);
 }
 
@@ -72,7 +75,7 @@ void testLLVMIntToFloatCastTest() {
   KernelScope kernel_scope;
   auto a = IntImm::make(2);
   auto b = Cast::make(kFloat32, a);
-  LLVMCodeGen cg(b, {}, kFloat32);
+  LLVMExprEval cg(b, {});
   EXPECT_EQ(cg.value<float>(), 2.0);
 }
 
@@ -80,7 +83,7 @@ void testLLVMFloatToIntCastTest() {
   KernelScope kernel_scope;
   auto a = FloatImm::make(2.0);
   auto b = Cast::make(kInt32, a);
-  LLVMCodeGen cg(b);
+  LLVMExprEval cg(b);
   EXPECT_EQ(cg.value<int>(), 2);
 }
 
@@ -90,7 +93,7 @@ void testLLVMLetTest01() {
   Expr value = Expr(3.f);
   Expr body = Expr(2.f) + (x * Expr(3.f) + Expr(4.f));
   Expr result = Let::make(x, Expr(3.f), body);
-  LLVMCodeGen cg(result, {}, kFloat32);
+  LLVMExprEval cg(result, {});
   EXPECT_EQ(cg.value<float>(), 2.f + (3.f * 3.f + 4.f));
 }
 
@@ -102,7 +105,7 @@ void testLLVMLetTest02() {
   Expr body = Expr(2.f) + (x * Expr(3.f) + Expr(4.f) * y);
   Expr e1 = Let::make(x, Expr(3.f), body);
   Expr e2 = Let::make(y, Expr(6.f), e1);
-  LLVMCodeGen cg(e2, {}, kFloat32);
+  LLVMExprEval cg(e2, {});
   EXPECT_EQ(cg.value<float>(), 2.f + (3.f * 3.f + 4.f * 6.f));
 }
 
@@ -112,7 +115,7 @@ void testLLVMBufferTest() {
   std::vector<int32_t> v(5);
   std::vector<void*> args({v.data()});
   auto rv = IntImm::make(0);
-  LLVMCodeGen cg(rv, {a});
+  LLVMExprEval cg(rv, {a});
   EXPECT_EQ(cg.value<int>(args), 0);
 }
 

--- a/test/cpp/tensorexpr/test_utils.h
+++ b/test/cpp/tensorexpr/test_utils.h
@@ -1,10 +1,14 @@
 #pragma once
 
-#include <torch/csrc/jit/testing/file_check.h>
+#include <memory>
+#include <vector>
+
 #include "test/cpp/tensorexpr/test_base.h"
+#include "torch/csrc/jit/testing/file_check.h"
 
 namespace torch {
 namespace jit {
+using namespace torch::jit::tensorexpr;
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -27,30 +27,11 @@ RegisterCodeGenList::StmtFactoryMethod RegisterCodeGenList::
   return iter->second;
 }
 
-RegisterCodeGenList::ExprFactoryMethod RegisterCodeGenList::
-    FindExprFactoryMethod(const std::string& name) {
-  auto iter = expr_factory_methods_.find(name);
-  if (iter == expr_factory_methods_.end()) {
-    throw std::runtime_error("Invalid expr codegen name: " + name);
-  }
-  return iter->second;
-}
-
 void RegisterCodeGenList::AddStmtFactoryMethod(
     const std::string& name,
     StmtFactoryMethod stmt_factory_method) {
   auto insert_ret =
       stmt_factory_methods_.insert(std::make_pair(name, stmt_factory_method));
-  if (!insert_ret.second) {
-    throw std::runtime_error("Duplicated CodeGen names: " + name);
-  }
-}
-
-void RegisterCodeGenList::AddExprFactoryMethod(
-    const std::string& name,
-    ExprFactoryMethod expr_factory_method) {
-  auto insert_ret =
-      expr_factory_methods_.insert(std::make_pair(name, expr_factory_method));
   if (!insert_ret.second) {
     throw std::runtime_error("Duplicated CodeGen names: " + name);
   }
@@ -63,15 +44,6 @@ std::unique_ptr<CodeGen> CreateCodeGen(
   RegisterCodeGenList::StmtFactoryMethod method =
       RegisterCodeGenList::GetInstance().FindStmtFactoryMethod(name);
   return method(stmt, params);
-}
-
-std::unique_ptr<CodeGen> CreateCodeGen(
-    const std::string& name,
-    const Expr& expr,
-    const std::vector<CodeGen::BufferArg>& params) {
-  RegisterCodeGenList::ExprFactoryMethod method =
-      RegisterCodeGenList::GetInstance().FindExprFactoryMethod(name);
-  return method(expr, params);
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -144,7 +144,7 @@ void CudaCodeGen::Initialize() {
   oss_ << ") {";
 
   oss_ << std::endl;
-  ir_node()->accept(printer_.get());
+  stmt().accept(printer_.get());
   oss_ << std::endl;
   oss_ << "}";
 

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -9,21 +9,15 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
-// The commomn class between all IR nodes.
-class IRNode : public KernelScopedObject {
- public:
-  TORCH_API virtual void accept(IRVisitor* visitor) const = 0;
-  TORCH_API virtual ~IRNode() {}
-};
-
 // The common base between all expression node.
 class Expr;
-class BaseExprNode : public IRNode {
+class BaseExprNode : public KernelScopedObject {
  public:
   explicit BaseExprNode(Dtype dtype) : dtype_(dtype) {}
   Dtype dtype() const {
     return dtype_;
   }
+  TORCH_API virtual void accept(IRVisitor* visitor) const = 0;
   virtual Expr accept_mutator(IRMutator* mutator) = 0;
 
  private:
@@ -31,9 +25,10 @@ class BaseExprNode : public IRNode {
 };
 
 // The common base between all statement node.
-class BaseStmtNode : public IRNode {
+class BaseStmtNode : public KernelScopedObject {
  public:
   BaseStmtNode() {}
+  TORCH_API virtual void accept(IRVisitor* visitor) const = 0;
   virtual Stmt accept_mutator(IRMutator* mutator) = 0;
 };
 

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -560,6 +560,13 @@ class TORCH_API Store : public StmtNode<Store> {
     return Stmt(new Store(base_handle, index, value, mask));
   }
 
+  static Stmt make(
+      const Var& base_handle,
+      const Expr& index,
+      const Expr& value) {
+    return Stmt(new Store(base_handle, index, value, Expr(1)));
+  }
+
  private:
   // TODO: merge this with Load.
   Store(

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -50,29 +50,14 @@ static llvm::orc::JITTargetMachineBuilder makeTargetMachineBuilder() {
 #endif
 }
 
-LLVMCodeGen::LLVMCodeGen(
-    const Stmt& stmt,
-    const std::vector<BufferArg>& args,
-    Dtype dtype)
-    : LLVMCodeGen(stmt.node(), args, dtype) {}
-
 LLVMCodeGen::LLVMCodeGen(const Stmt& stmt)
     : LLVMCodeGen(stmt, std::vector<BufferArg>()) {}
 
 LLVMCodeGen::LLVMCodeGen(
-    const Expr& expr,
+    const Stmt& stmt,
     const std::vector<BufferArg>& args,
     Dtype dtype)
-    : LLVMCodeGen(expr.node(), args, dtype) {}
-
-LLVMCodeGen::LLVMCodeGen(const Expr& expr)
-    : LLVMCodeGen(expr, std::vector<BufferArg>()) {}
-
-LLVMCodeGen::LLVMCodeGen(
-    const IRNode* node,
-    const std::vector<BufferArg>& args,
-    Dtype dtype)
-    : CodeGen(node, args),
+    : CodeGen(stmt, args),
       context_(std::make_unique<llvm::LLVMContext>()),
       irb_(getContext()),
       int32Ty_(llvm::Type::getInt32Ty(getContext())),
@@ -110,7 +95,7 @@ LLVMCodeGen::LLVMCodeGen(
   }
 
   emitWrapper(params);
-  emitKernel(node, params);
+  emitKernel(stmt, params);
 
   cantFail(jit_->addModule(
       llvm::orc::ThreadSafeModule(std::move(module_), context_)));
@@ -166,14 +151,14 @@ void LLVMCodeGen::emitWrapper(const std::vector<llvm::Type*>& params) {
 }
 
 void LLVMCodeGen::emitKernel(
-    const IRNode* node,
+    const Stmt& stmt,
     const std::vector<llvm::Type*>& params) {
   // Set insert point to the real function.
   bb_ = llvm::BasicBlock::Create(getContext(), "entry", fn_);
   irb_.SetInsertPoint(bb_);
 
   // Compile the kernel.
-  node->accept(this);
+  stmt.accept(this);
   irb_.CreateRet(value_);
 
 #if DEBUG_PRINT

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.h
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.h
@@ -46,16 +46,11 @@ class TORCH_API LLVMCodeGen : public CodeGen, public IRVisitor {
   std::vector<void*> args_;
 
  private:
-  explicit LLVMCodeGen(
-      const IRNode* node,
-      const std::vector<BufferArg>& args,
-      Dtype dtype = kInt32);
-
   llvm::LLVMContext& getContext();
   llvm::Type* dtypeToLLVM(Dtype dtype);
   llvm::Type* dtypeToLLVMPtr(Dtype dtype);
   void emitWrapper(const std::vector<llvm::Type*>& params);
-  void emitKernel(const IRNode* node, const std::vector<llvm::Type*>& params);
+  void emitKernel(const Stmt& stmt, const std::vector<llvm::Type*>& params);
 
  public:
   explicit LLVMCodeGen(
@@ -63,11 +58,6 @@ class TORCH_API LLVMCodeGen : public CodeGen, public IRVisitor {
       const std::vector<BufferArg>& args,
       Dtype dtype = kInt32);
   explicit LLVMCodeGen(const Stmt& stmt);
-  explicit LLVMCodeGen(
-      const Expr& expr,
-      const std::vector<BufferArg>& args,
-      Dtype dtype = kInt32);
-  explicit LLVMCodeGen(const Expr& expr);
 
   ~LLVMCodeGen() override {}
 

--- a/torch/csrc/jit/tensorexpr/schedule.cpp
+++ b/torch/csrc/jit/tensorexpr/schedule.cpp
@@ -21,9 +21,8 @@ namespace {
 // Evaluates a constant expression and returns its value.
 template <typename T>
 static T EvalConstExpr(const Expr& expr) {
-  SimpleIREvaluator eval(expr);
-  eval();
-  return eval.value().as<T>();
+  ExprEval<SimpleIREvaluator> eval(expr);
+  return eval.value<T>();
 }
 
 } // namespace


### PR DESCRIPTION
CodeGen accepts only Stmt. 
Add ExprEval utility wrapper.
