### PR TITLE
Change the default block size from 1024 to 512.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -610,7 +610,7 @@ void TensorExprKernel::LowerToBackend(BackendType backend_type) {
       Var index = tensor.arg(0);
       Var outer;
       Var inner;
-      tensor.SplitWithMask(index, 1024, true, &outer, &inner);
+      tensor.SplitWithMask(index, 512, true, &outer, &inner);
       tensor.GPUExecConfig({outer}, {inner});
     }
   }


### PR DESCRIPTION
$ (PYTHONPATH=$PWD python benchmarks/tensorexpr/benchmark.py element broadcast --device gpu --mode fwd --jit_mode trace) |& tee /tmp/01.txt
pt: element_split_mul_fwd_cuda_134217728: 3281.45 us, SOL 818.04 GB/s, algorithmic 818.04 GB/s
pt: element_split_add_fwd_cuda_134217728: 3282.54 us, SOL 817.77 GB/s, algorithmic 817.77 GB/s
pt: element_split_sub_fwd_cuda_134217728: 3282.69 us, SOL 817.73 GB/s, algorithmic 817.73 GB/s
pt: element_split_div_fwd_cuda_134217728: 3308.66 us, SOL 811.31 GB/s, algorithmic 811.31 GB/s
pt: element_split_pow_fwd_cuda_134217728: 3516.52 us, SOL 763.35 GB/s, algorithmic 763.35 GB/s
pt: element_split_max_fwd_cuda_134217728: 3282.74 us, SOL 817.72 GB/s, algorithmic 817.72 GB/s
pt: element_split_min_fwd_cuda_134217728: 3282.73 us, SOL 817.72 GB/s, algorithmic 817.72 GB/s
pt: element_shared_mul_fwd_cuda_134217728: 1356.76 us, SOL 791.40 GB/s, algorithmic 791.40 GB/s
pt: element_shared_add_fwd_cuda_134217728: 1356.73 us, SOL 791.42 GB/s, algorithmic 791.42 GB/s
pt: element_shared_sub_fwd_cuda_134217728: 1356.69 us, SOL 791.44 GB/s, algorithmic 791.44 GB/s
pt: element_shared_div_fwd_cuda_134217728: 1375.88 us, SOL 780.40 GB/s, algorithmic 780.40 GB/s
pt: element_shared_pow_fwd_cuda_134217728: 2296.72 us, SOL 467.51 GB/s, algorithmic 467.51 GB/s
pt: element_shared_max_fwd_cuda_134217728: 1356.51 us, SOL 791.55 GB/s, algorithmic 791.55 GB/s
pt: element_shared_min_fwd_cuda_134217728: 1356.51 us, SOL 791.55 GB/s, algorithmic 791.55 GB/s
pt: element_split_exp_fwd_cuda_134217728: 3289.87 us, SOL 815.95 GB/s, algorithmic 815.95 GB/s
pt: element_split_sin_fwd_cuda_134217728: 3478.14 us, SOL 771.78 GB/s, algorithmic 771.78 GB/s
pt: element_split_cos_fwd_cuda_134217728: 3479.85 us, SOL 771.40 GB/s, algorithmic 771.40 GB/s
pt: element_shared_exp_fwd_cuda_134217728: 1377.77 us, SOL 779.33 GB/s, algorithmic 779.33 GB/s
pt: element_shared_sin_fwd_cuda_134217728: 1826.81 us, SOL 587.77 GB/s, algorithmic 587.77 GB/s
pt: element_shared_cos_fwd_cuda_134217728: 1840.52 us, SOL 583.39 GB/s, algorithmic 583.39 GB/s
pt: broadcast_split_mul_fwd_cuda_256_128_512: 111.39 us, SOL 602.47 GB/s, algorithmic 602.47 GB/s
pt: broadcast_split_add_fwd_cuda_256_128_512: 111.63 us, SOL 601.18 GB/s, algorithmic 601.18 GB/s
pt: broadcast_split_sub_fwd_cuda_256_128_512: 111.69 us, SOL 600.83 GB/s, algorithmic 600.83 GB/s
pt: broadcast_split_div_fwd_cuda_256_128_512: 166.97 us, SOL 401.91 GB/s, algorithmic 401.91 GB/s
pt: broadcast_split_pow_fwd_cuda_256_128_512: 310.92 us, SOL 215.84 GB/s, algorithmic 215.84 GB/s
pt: broadcast_split_max_fwd_cuda_256_128_512: 112.62 us, SOL 595.91 GB/s, algorithmic 595.91 GB/s
pt: broadcast_split_min_fwd_cuda_256_128_512: 112.58 us, SOL 596.09 GB/s, algorithmic 596.09 GB/s
pt: broadcast_shared_mul_fwd_cuda_256_128_512: 109.32 us, SOL 613.85 GB/s, algorithmic 613.85 GB/s
pt: broadcast_shared_add_fwd_cuda_256_128_512: 109.37 us, SOL 613.60 GB/s, algorithmic 613.60 GB/s
pt: broadcast_shared_sub_fwd_cuda_256_128_512: 109.36 us, SOL 613.63 GB/s, algorithmic 613.63 GB/s
pt: broadcast_shared_div_fwd_cuda_256_128_512: 162.10 us, SOL 414.00 GB/s, algorithmic 414.00 GB/s
pt: broadcast_shared_pow_fwd_cuda_256_128_512: 303.95 us, SOL 220.79 GB/s, algorithmic 220.79 GB/s
pt: broadcast_shared_max_fwd_cuda_256_128_512: 110.34 us, SOL 608.20 GB/s, algorithmic 608.20 GB/s
pt: broadcast_shared_min_fwd_cuda_256_128_512: 110.20 us, SOL 608.95 GB/s, algorithmic 608.95 GB/s
pt: broadcast_split_exp_fwd_cuda_256_128_512: 146.12 us, SOL 459.27 GB/s, algorithmic 459.27 GB/s
pt: broadcast_split_sin_fwd_cuda_256_128_512: 224.09 us, SOL 299.47 GB/s, algorithmic 299.47 GB/s
pt: broadcast_split_cos_fwd_cuda_256_128_512: 225.54 us, SOL 297.54 GB/s, algorithmic 297.54 GB/s
pt: broadcast_shared_exp_fwd_cuda_256_128_512: 141.29 us, SOL 474.97 GB/s, algorithmic 474.97 GB/s
pt: broadcast_shared_sin_fwd_cuda_256_128_512: 220.59 us, SOL 304.22 GB/s, algorithmic 304.22 GB/s
pt: broadcast_shared_cos_fwd_cuda_256_128_512: 221.44 us, SOL 303.06 GB/s, algorithmic 303.06 GB/s

