### PR TITLE
Add guard elimination support for aten::unsqueeze. (#33371)

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -6510,6 +6510,18 @@ a")
             bailout_graph_str = str(my_slice.graph_for(a))
             FileCheck().check_count("prim::BailOut", 1).run(bailout_graph_str)
 
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "skip if profiling isn't enabled")
+    def test_unsqueeze_guard_elimination(self):
+        @torch.jit.script
+        def my_unsqueeze(x):
+            return torch.unsqueeze(x, 0) + torch.unsqueeze(x, 0)
+
+        a = torch.rand(32, 4)
+
+        with enable_profiling_mode():
+            my_unsqueeze(a)
+            bailout_graph_str = str(my_unsqueeze.graph_for(a))
+            FileCheck().check_count("prim::BailOut", 2).run(bailout_graph_str)
 
     def test_resize_input_ops(self):
         # resize_ and resize_as resize the input tensor. because our shape analysis

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -283,6 +283,10 @@ private:
              n->input(3)->node()->kind() == prim::Constant &&
              // the stride is constant
              n->input(4)->node()->kind() == prim::Constant;
+    case aten::unsqueeze:
+     // check that the dimension argument is constant
+     return !n->input(0)->type()->expect<TensorType>()->isSummarized() &&
+            n->input(1)->node()->kind() == prim::Constant;
     case aten::cat:
       // check that the dimension argument is constant
       return n->input(1)->node()->kind() == prim::Constant &&


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/33371

Differential Revision: D19920041

Pulled By: resistor

fbshipit-source-id: 906af47676dba014c31eef069a4753207f2efc60

