### PR TITLE
Use c10 type promotion rules directly

### DIFF
--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -142,7 +142,7 @@ void CudaPrinter::visit(const Intrinsics* v) {
   ScalarType returnType = v->param(0)->dtype().scalar_type();
   for (int i = 1; i < v->nparams(); ++i) {
     returnType =
-        promoteNumericTypes(returnType, v->param(i)->dtype().scalar_type());
+        promoteTypes(returnType, v->param(i)->dtype().scalar_type());
   }
 
   if (returnType == ScalarType::Half || returnType == ScalarType::Float) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -95,7 +95,7 @@ void TensorExprKernel::promoteInputs(std::vector<ExprHandle>& inputs) {
     if (iType == ScalarType::Bool) {
       continue;
     }
-    highType = promoteNumericTypes(highType, iType);
+    highType = promoteTypes(highType, iType);
   }
 
   for (ExprHandle& e : inputs) {

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -67,52 +67,6 @@ Dtype ToDtype(ScalarType type) {
   }
 }
 
-/* Type promotion rules are taken from torch.Tensor attributes.
- * Simple version is: largest floating type, then largest integer type. */
-ScalarType promoteNumericTypes(ScalarType a, ScalarType b) {
-  bool floatA = is_floating_point(a);
-  bool floatB = is_floating_point(b);
-
-  // Only support numeric types.
-  if ((!floatA && !is_integral(a)) || (!floatB && !is_integral(b))) {
-    return ScalarType::Undefined;
-  }
-
-  // Equal types remain the same.
-  if (a == b) {
-    return a;
-  }
-
-  // If either are floats, then take the bitwidth of the widest float component.
-  if (floatA || floatB) {
-    if (a == ScalarType::Double || b == ScalarType::Double) {
-      return ScalarType::Double;
-    }
-
-    if (a == ScalarType::Float || b == ScalarType::Float) {
-      return ScalarType::Float;
-    }
-
-    return ScalarType::Half;
-  }
-
-  // If only integers, take the widest bitwidth.
-  if (a == ScalarType::Long || b == ScalarType::Long) {
-    return ScalarType::Long;
-  }
-
-  if (a == ScalarType::Int || b == ScalarType::Int) {
-    return ScalarType::Int;
-  }
-
-  if (a == ScalarType::Short || b == ScalarType::Short) {
-    return ScalarType::Short;
-  }
-
-  // Remaining combination is Byte and Char.
-  return ScalarType::Short;
-}
-
 TORCH_API std::ostream& operator<<(std::ostream& stream, const Dtype& dtype) {
   stream << dtype.scalar_type_;
   if (dtype.lanes() > 1) {

--- a/torch/csrc/jit/tensorexpr/types.h
+++ b/torch/csrc/jit/tensorexpr/types.h
@@ -95,9 +95,15 @@ AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, NNC_TODTYPE_DECLARATION)
 
 TORCH_API Dtype ToDtype(ScalarType type);
 
-TORCH_API ScalarType promoteNumericTypes(ScalarType a, ScalarType b);
-inline ScalarType promoteNumericTypes(Dtype a, Dtype b) {
-  return promoteNumericTypes(a.scalar_type(), b.scalar_type());
+// Call c10 type promotion directly.
+inline ScalarType promoteTypes(ScalarType a, ScalarType b) {
+  return static_cast<ScalarType>(c10::promoteTypes(
+      static_cast<c10::ScalarType>(a), static_cast<c10::ScalarType>(b)));
+}
+inline ScalarType promoteTypes(Dtype a, Dtype b) {
+  return static_cast<ScalarType>(c10::promoteTypes(
+      static_cast<c10::ScalarType>(a.scalar_type()),
+      static_cast<c10::ScalarType>(b.scalar_type())));
 }
 
 inline Dtype BinaryOpDtype(
@@ -115,7 +121,7 @@ inline Dtype BinaryOpDtype(
   CHECK_EQ(op1_dtype.lanes(), op2_dtype.lanes()) << "vector lengths must match";
   int lanes = op1_dtype.lanes();
 
-  ScalarType resultType = promoteNumericTypes(op1_dtype, op2_dtype);
+  ScalarType resultType = promoteTypes(op1_dtype, op2_dtype);
   CHECK_NE(resultType, ScalarType::Undefined)
       << "Invalid dtypes: " << op1_dtype << ", " << op2_dtype;
 


### PR DESCRIPTION
Rather than reimplement type promotion rules use the fast lookup table version baked into c10 ScalarType.