### PR TITLE
Fix bitwise ops in the evaluator

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -384,6 +384,17 @@ void testExprBinaryMath01() {
   }
 }
 
+void testExprBitwiseOps() {
+  KernelScope kernel_scope;
+  ExprHandle a(59);
+  ExprHandle b(11);
+  ExprHandle c(101);
+  ExprHandle f = ((a ^ (b << 1)) & c) >> 2;
+
+  SimpleIRExprEval eval(f);
+  EXPECT_EQ(eval.value<int>(), 9);
+}
+
 void testExprDynamicShapeAdd() {
   KernelScope kernel_scope;
   auto testWithSize = [](int32_t size) {

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -29,6 +29,7 @@ namespace jit {
   _(ExprUnaryMath01)            \
   _(ExprBinaryMath01)           \
   _(ExprDynamicShapeAdd)        \
+  _(ExprBitwiseOps)             \
   _(IRPrinterBasicValueTest)    \
   _(IRPrinterBasicValueTest02)  \
   _(IRPrinterLetTest01)         \

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -164,6 +164,19 @@ AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
     visit_binary_op(v, v->propagate_nans());
   }
 
+  TORCH_API void visit(const And* v) override {
+    visit_binary_op(v);
+  }
+  TORCH_API void visit(const Xor* v) override {
+    visit_binary_op(v);
+  }
+  TORCH_API void visit(const Lshift* v) override {
+    visit_binary_op(v);
+  }
+  TORCH_API void visit(const Rshift* v) override {
+    visit_binary_op(v);
+  }
+
   void visit(const CompareSelect* v) override {
     visit_compare_select_op(v, v->compare_select_op());
   }
@@ -306,7 +319,7 @@ AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
     CHECK_EQ(lhs_v.dtype(), rhs_v.dtype());
     IRNodeType expr_type = v->expr_type();
     if (expr_type == IRNodeType::kAnd || expr_type == IRNodeType::kXor ||
-        expr_type == IRNodeType::kLshift || expr_type == IRNodeType::kLshift) {
+        expr_type == IRNodeType::kLshift || expr_type == IRNodeType::kRshift) {
       value_ = bitwise_binary_op(lhs_v, rhs_v, expr_type);
       return;
     }


### PR DESCRIPTION
Hook up bitwise AND and XOR, LShift and RShift in the Evaluator and add a test.