### PR TITLE
Constant folding for binary ops + intrinsics on scalar immediates

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -1,0 +1,174 @@
+#include "test/cpp/tensorexpr/test_base.h"
+
+#include "test/cpp/tensorexpr/test_utils.h"
+#include "torch/csrc/jit/tensorexpr/constant_folder.h"
+
+namespace torch {
+namespace jit {
+using namespace torch::jit::tensorexpr;
+using SimpleIRExprEval = ExprEval<SimpleIREvaluator>;
+
+void testConstantFoldSimple() {
+  KernelScope kernel_scope;
+  ExprHandle a(2.0f);
+  ExprHandle b(3.0f);
+  ExprHandle f = (a + b);
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(f.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<FloatImm>(), nullptr);
+  EXPECT_EQ(newF.AsNode<FloatImm>()->value(), 5);
+
+  SimpleIRExprEval eval(newF);
+  EXPECT_EQ(eval.value<float>(), 5.f);
+}
+
+void testConstantFoldTwoLayer() {
+  KernelScope kernel_scope;
+  ExprHandle a(2.0f);
+  ExprHandle b(3.0f);
+  ExprHandle c(4.0f);
+  ExprHandle d(5.0f);
+  ExprHandle f = (a + b) - (c + d);
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(f.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<FloatImm>(), nullptr);
+  EXPECT_EQ(newF.AsNode<FloatImm>()->value(), -4);
+
+  SimpleIRExprEval eval(newF);
+  EXPECT_EQ(eval.value<float>(), -4.f);
+}
+
+void testConstantFoldShifts() {
+  KernelScope kernel_scope;
+  ExprHandle a(7);
+  ExprHandle b(2);
+  ExprHandle c(3);
+  ExprHandle f = ((a << b) << b) >> c;
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(f.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<IntImm>(), nullptr);
+  EXPECT_EQ(newF.AsNode<IntImm>()->value(), 14);
+
+  SimpleIRExprEval eval(newF);
+  EXPECT_EQ(eval.value<int>(), 7 << (4-3));
+}
+
+void testConstantFoldBitwise() {
+  KernelScope kernel_scope;
+  ExprHandle a(59);
+  ExprHandle b(22);
+  ExprHandle c(101);
+  ExprHandle f = (a ^ b) & c;
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(f.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<IntImm>(), nullptr);
+  EXPECT_EQ(newF.AsNode<IntImm>()->value(), 37);
+
+  SimpleIRExprEval eval(newF);
+  EXPECT_EQ(eval.value<int>(), (59 ^ 22) & 101);
+}
+
+void testConstantFoldMultiOp() {
+  KernelScope kernel_scope;
+  ExprHandle a(2.0f);
+  ExprHandle b(3.0f);
+  ExprHandle c(4.0f);
+  ExprHandle d(5.0f);
+  ExprHandle e(6.0f);
+  ExprHandle f(7.0f);
+  ExprHandle fn = ((a / e) - (c + d)) * (f / b);
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(fn.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<FloatImm>(), nullptr);
+
+  SimpleIRExprEval eval(newF);
+  SimpleIRExprEval ref(fn);
+
+  EXPECT_EQ(eval.value<float>(), ref.value<float>());
+}
+
+void testConstantFoldMinMax() {
+  KernelScope kernel_scope;
+  ExprHandle a(12.0f);
+  ExprHandle b(15.0f);
+  ExprHandle c(17.0f);
+
+  // x = max(12, min(15, 17)).
+  ExprHandle minHandle = Min::make(b, c, true);
+  ExprHandle fn = Max::make(a, minHandle, false);
+
+  EXPECT_EQ(fn.dtype().scalar_type(), ScalarType::Float);
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(fn.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<FloatImm>(), nullptr);
+
+  SimpleIRExprEval eval(newF);
+  EXPECT_EQ(eval.value<float>(), 15.f);
+}
+
+void testConstantFoldIntrinsics() {
+  KernelScope kernel_scope;
+  ExprHandle a(2.0f);
+  ExprHandle b(3.0f);
+  ExprHandle c(4.0f);
+  ExprHandle powHandle = Intrinsics::make(kPow, a, b);
+  ExprHandle sinHandle = Intrinsics::make(kSin, powHandle);
+  ExprHandle modHandle = Intrinsics::make(kFmod, c, sinHandle);
+  ExprHandle logHandle = Intrinsics::make(kLog10, modHandle);
+  ExprHandle rndHandle = Intrinsics::make(kRound, logHandle);
+  ExprHandle fn = Intrinsics::make(kFabs, rndHandle);
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(fn.node()->accept_mutator(&folder));
+  EXPECT_NE(newF.AsNode<FloatImm>(), nullptr);
+  EXPECT_EQ(newF.AsNode<FloatImm>()->value(), 1);
+
+  SimpleIRExprEval eval(newF);
+  SimpleIRExprEval ref(fn);
+
+  EXPECT_EQ(eval.value<float>(), ref.value<float>());
+}
+
+void testConstantFoldWithVar() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kFloat);
+  ExprHandle body = x * (ExprHandle(2.f) + ExprHandle(4.f));
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(body.node()->accept_mutator(&folder));
+  const Mul* root = newF.AsNode<Mul>();
+  EXPECT_NE(root, nullptr);
+  EXPECT_NE(dynamic_cast<const FloatImm*>(root->rhs()), nullptr);
+
+  ExprHandle result = Let::make(x, ExprHandle(3.f), newF);
+  SimpleIRExprEval eval(result);
+  EXPECT_EQ(eval.value<float>(), 3 * (2 + 4));
+}
+
+void testUnFoldableExpr() {
+  KernelScope kernel_scope;
+  VarHandle x("x", kFloat);
+  VarHandle y("y", kFloat);
+  ExprHandle body = (ExprHandle(3) * x) + (ExprHandle(5) * y);
+
+  ConstantFolder folder;
+  ExprHandle newF = ExprHandle(body.node()->accept_mutator(&folder));
+  const Add* root = newF.AsNode<Add>();
+  EXPECT_NE(root, nullptr);
+  EXPECT_EQ(dynamic_cast<const FloatImm*>(root->lhs()), nullptr);
+  EXPECT_EQ(dynamic_cast<const FloatImm*>(root->rhs()), nullptr);
+
+  ExprHandle result = Let::make(x, ExprHandle(3.f), newF);
+  result = Let::make(y, ExprHandle(2.f), result);
+  SimpleIRExprEval eval(result);
+  EXPECT_EQ(eval.value<float>(), 9 + 10);
+}
+
+} // namespace jit
+} // namespace torch

--- a/test/cpp/tensorexpr/tests.h
+++ b/test/cpp/tensorexpr/tests.h
@@ -1,5 +1,6 @@
 #pragma once
 
+
 /**
  * See README.md for instructions on how to add a new test.
  */
@@ -84,7 +85,16 @@ namespace jit {
   _(ATengeInt)                  \
   _(ATengtInt)                  \
   _(ATenleInt)                  \
-  _(ATenltInt)
+  _(ATenltInt)                  \
+  _(ConstantFoldSimple)         \
+  _(ConstantFoldTwoLayer)       \
+  _(ConstantFoldShifts)         \
+  _(ConstantFoldBitwise)        \
+  _(ConstantFoldMultiOp)        \
+  _(ConstantFoldMinMax)         \
+  _(ConstantFoldIntrinsics)     \
+  _(ConstantFoldWithVar)        \
+  _(UnFoldableExpr)
 
 #define TH_FORALL_TESTS_LLVM(_) \
   _(LLVMByteImmTest)            \

--- a/torch/csrc/jit/tensorexpr/constant_folder.h
+++ b/torch/csrc/jit/tensorexpr/constant_folder.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include "torch/csrc/jit/tensorexpr/eval.h"
+#include "torch/csrc/jit/tensorexpr/ir_mutator.h"
+#include "torch/csrc/jit/tensorexpr/ir_visitor.h"
+#include "torch/csrc/jit/tensorexpr/types.h"
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+/* Mutate the IR by collapsing expressions with constant terms down to a single
+ * immediate. Uses the IR Evaluator as a source of truth.
+ */
+class ConstantFolder : public IRMutator {
+ public:
+  const Expr* mutate(const Add* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Sub* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Mul* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Div* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Mod* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const And* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Xor* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Lshift* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Rshift* v) override {
+    return mutateBinaryOp(v, this);
+  }
+
+  const Expr* mutate(const Max* v) override {
+    return mutateBinaryOp(v, this, v->propagate_nans());
+  }
+
+  const Expr* mutate(const Min* v) override {
+    return mutateBinaryOp(v, this, v->propagate_nans());
+  }
+
+  const Expr* mutate(const Intrinsics* v) override {
+    std::vector<const Expr*> new_params;
+    bool changed = false;
+    bool allConstant = true;
+    for (const auto* p : v->params()) {
+      const Expr* new_child =  p->accept_mutator(this);
+      new_params.push_back(new_child);
+
+      changed |= p != new_child;
+      allConstant &= new_child->isConstant();
+    }
+
+    const Expr* node = v;
+    if (changed) {
+      node = new Intrinsics(v->op_type(), new_params);
+    }
+
+    if (!allConstant) {
+      return node;
+    }
+
+    return evaluateOp(node);
+  }
+
+ private:
+  static const Expr* evaluateOp(const Expr* v) {
+    ExprHandle handle(v);
+    ExprEval<SimpleIREvaluator> eval(handle);
+
+    switch (v->dtype().scalar_type()) {
+#define TYPE_CASE(Type, Name)                                        \
+  case ScalarType::Name: {                                           \
+    Type val = eval.value<Type>();                                   \
+    return getImmediateByType(v->dtype().scalar_type(), val).node(); \
+  }
+      AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+#undef TYPE_CASE
+      default:
+        LOG(FATAL) << "Unsupported datatype: " << v->dtype();
+        return nullptr;
+    }
+    return nullptr;
+  }
+
+  static const Expr* newBinaryOpOfType(
+      IRNodeType expr_type,
+      const Expr* lhs,
+      const Expr* rhs,
+      bool option) {
+    switch (expr_type) {
+      case IRNodeType::kAdd:
+        return new Add(lhs, rhs);
+      case IRNodeType::kSub:
+        return new Sub(lhs, rhs);
+      case IRNodeType::kMul:
+        return new Mul(lhs, rhs);
+      case IRNodeType::kDiv:
+        return new Div(lhs, rhs);
+      case IRNodeType::kMod:
+        return new Mod(lhs, rhs);
+      case IRNodeType::kMax:
+        return new Max(lhs, rhs, option);
+      case IRNodeType::kMin:
+        return new Min(lhs, rhs, option);
+      case IRNodeType::kAnd:
+        return new And(lhs, rhs);
+      case IRNodeType::kXor:
+        return new Xor(lhs, rhs);
+      case IRNodeType::kLshift:
+        return new Lshift(lhs, rhs);
+      case IRNodeType::kRshift:
+        return new Rshift(lhs, rhs);
+      default:
+        LOG(FATAL) << "unsupported expr_type: " << static_cast<int>(expr_type);
+        return nullptr;
+    }
+  }
+
+  template <typename Op>
+  static const Expr* mutateBinaryOp(
+      const BinaryOpNode<Op>* v,
+      IRMutator* mutator,
+      bool option = false) {
+    const Expr* lhs = v->lhs();
+    const Expr* rhs = v->rhs();
+    const Expr* lhs_new = lhs->accept_mutator(mutator);
+    const Expr* rhs_new = rhs->accept_mutator(mutator);
+
+    const Expr* node = v;
+
+    if (lhs != lhs_new || rhs != rhs_new) {
+      node = newBinaryOpOfType(v->expr_type(), lhs_new, rhs_new, option);
+    }
+
+    // Can only fold if both sides are constant.
+    if (!lhs_new->isConstant() || !rhs_new->isConstant()) {
+      return node;
+    }
+
+    return evaluateOp(node);
+  }
+};
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -48,6 +48,8 @@ class Expr : public KernelScopedObject {
   IRNodeType expr_type() const {
     return expr_type_;
   }
+  // Is this a fixed (constant) immediate value.
+  virtual bool isConstant() const { return false; }
 
  private:
   Dtype dtype_;

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -240,6 +240,7 @@ class Min : public BinaryOpNode<Min> {
    public:                                                    \
     Name##Imm(Type value)                                     \
         : ExprNodeBase(k##Name, kPrimitive), value_(value) {} \
+    bool isConstant() const override { return true; }               \
     Type value() const {                                      \
       return value_;                                          \
     }                                                         \
@@ -252,6 +253,21 @@ class Min : public BinaryOpNode<Min> {
   };
 AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, IMM_DECLARE);
 #undef IMM_DECLARE
+
+// Get immediate by ScalarType.
+template <typename T>
+ExprHandle getImmediateByType(ScalarType immType, T initialVal) {
+  switch (immType) {
+#define TYPE_CASE(Type, Name) \
+  case ScalarType::Name:      \
+    return Name##Imm::make(initialVal);
+    AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
+#undef TYPE_CASE
+    default:
+      LOG(FATAL) << "Unsupported datatype: " << immType;
+  }
+  return ExprHandle();
+}
 
 // Bind the value to the var and evaluate the body.
 class Let : public ExprNode<Let> {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1,4 +1,6 @@
 #include <torch/csrc/jit/tensorexpr/kernel.h>
+
+#include <torch/csrc/jit/tensorexpr/constant_folder.h>
 #include <torch/csrc/jit/tensorexpr/ir_printer.h>
 #include <torch/csrc/jit/tensorexpr/schedule.h>
 
@@ -996,6 +998,9 @@ void TensorExprKernel::LowerToBackend(BackendType backend_type) {
 
   l.ApplyInlines();
   Stmt* stmt = l.root_stmt();
+
+  ConstantFolder constant_folder;
+  stmt = stmt->accept_mutator(&constant_folder);
 
   // Set up formal params (inputs, then outputs) for kernel.
   std::vector<CodeGen::BufferArg> params;

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -132,9 +132,10 @@ std::string Dtype::ToCppString() const {
     case ScalarType::Half:
       return "half";
     default:
-      throw std::runtime_error(
-          "Invalid dtype: " + std::to_string(scalar_type_));
+      LOG(FATAL) << "ToCppString Invalid dtype: "
+                 << std::to_string(scalar_type_);
   }
+  return "invalid";
 }
 
 } // namespace tensorexpr


### PR DESCRIPTION
Adds a simple constant folder for arithmetic: recursively finds terms which have only constant inputs and evaluates them using the SimpleIREvaluator.

Wasn't sure where to actually do the work, so I put it after lowering.