### PR TITLE
Make a bunch of changes to Stmt semantics.

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -270,8 +270,7 @@ Stmt* IRMutator::mutate(const For* v) {
 Stmt* IRMutator::mutate(const Block* v) {
   bool any_change = false;
   std::vector<Stmt*> stmts;
-  for (int i = 0; i < v->nstmts(); i++) {
-    Stmt* stmt = v->stmt(i);
+  for (Stmt* stmt : v->stmts()) {
     Stmt* stmt_new = stmt->accept_mutator(this);
     if (stmt != stmt_new) {
       any_change = true;

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -200,8 +200,8 @@ void IRPrinter::visit(const For* v) {
 }
 
 void IRPrinter::visit(const Block* v) {
-  for (int i = 0; i < v->nstmts(); ++i) {
-    os() << *v->stmt(i) << std::endl;
+  for (Stmt *s : v->stmts()) {
+    os() << *s << std::endl;
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -104,8 +104,8 @@ void IRVisitor::visit(const Store* v) {
 }
 
 void IRVisitor::visit(const Block* v) {
-  for (int i = 0; i < v->nstmts(); i++) {
-    v->stmt(i)->accept(this);
+  for (Stmt* s : v->stmts()) {
+    s->accept(this);
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -772,8 +772,8 @@ void LLVMCodeGen::visit(const For* v) {
 }
 
 void LLVMCodeGen::visit(const Block* v) {
-  for (int i = 0; i < v->nstmts(); i++) {
-    v->stmt(i)->accept(this);
+  for (Stmt* s : v->stmts()) {
+    s->accept(this);
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/schedule.cpp
+++ b/torch/csrc/jit/tensorexpr/schedule.cpp
@@ -463,7 +463,7 @@ class Vectorizer : public IRMutator {
     std::vector<const Expr*> inputs = { v->lhs(), v->rhs(), v->ret_val1(), v->ret_val2() };
     return try_vectorize(v, inputs,
       [&](){
-        return CompareSelect::make(ExprHandle(inputs[0]), ExprHandle(inputs[1]), 
+        return CompareSelect::make(ExprHandle(inputs[0]), ExprHandle(inputs[1]),
                                    ExprHandle(inputs[2]), ExprHandle(inputs[3]),
                                    v->compare_select_op());
       });

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <list>
 #include <string>
 #include <vector>
 
@@ -78,16 +79,34 @@ class Block : public StmtNode<Block> {
     }
     return new Block(valid_stmts);
   }
+
   int nstmts() const {
     return stmts_.size();
   }
-  Stmt* stmt(int index) const {
-    return stmts_[index];
+
+  void append_stmt(Stmt *s) {
+    stmts_.push_back(s);
+  }
+  bool replace_stmt(Stmt* old_stmt, Stmt* new_stmt) {
+    auto pos = std::find(stmts_.begin(), stmts_.end(), old_stmt);
+    if (pos == stmts_.end()) {
+      return false;
+    }
+    stmts_.insert(pos, new_stmt);
+    stmts_.erase(pos);
+    return true;
+  }
+  std::list<Stmt*> stmts() const {
+    return stmts_;
   }
 
  private:
-  explicit Block(const std::vector<Stmt*>& stmts) : stmts_(stmts) {}
-  std::vector<Stmt*> stmts_;
+  explicit Block(const std::vector<Stmt*>& stmts) {
+    for (Stmt* s : stmts) {
+      stmts_.push_back(s);
+    }
+  }
+  std::list<Stmt*> stmts_;
 };
 
 class TORCH_API Store : public StmtNode<Store> {

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -433,6 +433,14 @@ class For : public StmtNode<For> {
     set_parent(body_, this);
   }
 
+  void set_gpu_block_index(int block_index) {
+    loop_options_.set_gpu_block_index(block_index);
+  }
+
+  void set_gpu_thread_index(int thread_index) {
+    loop_options_.set_gpu_thread_index(thread_index);
+  }
+
  private:
   const Var* var_;
   const Expr* start_;


### PR DESCRIPTION
Stmt now becomes mutable and we preform the following changes in order to make use of that:

* Body of a `Block` statement is converted from `vector` to `list`. This makes insertions and removals cheap.
* `Stmt` gets a pointer to a statement enclosing it (parent). This is useful for determining where to insert a statement in various transformations (i.e. it makes it possible to find a 'sibling' of the current statement).
* True/False statements of `Cond` and body of `For` now become `Block`. It slightly simplifies insertion of new statements.
* We expose mutators for `loop_options` in `For`.

These changes are a preparation for a big change in how loop transformations (schedule primitives) are implemented.