### PR TITLE
Fallback to interpreter on TE failure

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -312,10 +312,14 @@ void fuseTensorExprs(std::shared_ptr<Graph>& graph) {
 
 Operation createTensorExprOp(const Node* node) {
   auto kernel =
-      std::make_shared<tensorexpr::TensorExprKernel>(*node->g(attr::Subgraph));
+      std::make_shared<tensorexpr::TensorExprKernel>(node->g(attr::Subgraph));
   return [kernel](Stack& stack) {
     RECORD_FUNCTION("TensorExpr", std::vector<c10::IValue>());
-    kernel->run(stack);
+    try {
+      kernel->run(stack);
+    } catch (const std::runtime_error& e) {
+      kernel->fallback(stack);
+    }
     return 0;
   };
 }

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/runtime/interpreter.h>
 #include <torch/csrc/jit/tensorexpr/codegen.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 
@@ -44,9 +45,13 @@ inline std::vector<ExprHandle> computeIndicesToBroadcast(
 
 class TensorExprKernel {
  public:
-  explicit TensorExprKernel(const Graph& subgraph);
+  explicit TensorExprKernel(const std::shared_ptr<Graph>& subgraph);
 
   void run(Stack& stack);
+
+  void fallback(Stack& stack) {
+    InterpreterState(code_).run(stack);
+  }
 
  private:
   enum BackendType {
@@ -55,6 +60,10 @@ class TensorExprKernel {
     kLLVMCodeGen,
     kCudaCodeGen,
   };
+
+  void compile();
+
+  void runKernel(Stack& stack);
 
   ExprHandle constant(const torch::jit::Value* v);
 
@@ -206,6 +215,9 @@ class TensorExprKernel {
   BackendType backend_type_ = BackendType::kUninitialized;
   at::Device device_ = at::kCPU;
   std::vector<TypePtr> input_types_;
+  std::shared_ptr<Graph> graph_;
+  Code code_;
+  bool fallback_{false};
 };
 
 TORCH_API int& GetTECudaPointwiseLoopLevels();


### PR DESCRIPTION
If we encounter a problem while compiling or running a TE::group, we need an escape hatch to invoke the interpreter.  This diff uses the same escape hatch as the existing fuser.  In general we should try not to use it, but I'm not convinced we can detect all possible bad scenarios up-front during TE::group formation.