### PR TITLE
Cleanup Stmt's parent semantics and guarantees around it.

### DIFF
--- a/test/cpp/tensorexpr/test_expr.cpp
+++ b/test/cpp/tensorexpr/test_expr.cpp
@@ -477,7 +477,7 @@ void testStmtClone() {
       Store::make(VarHandle(a_buf.data()), index, 5, 1);
   Stmt* loop = For::make(index, 0, N, body);
 
-  Stmt* cloned_loop = clone(loop);
+  Stmt* cloned_loop = Stmt::clone(loop);
   std::vector<int> orig_loop_results(N);
   std::vector<int> cloned_loop_results(N);
   SimpleIREvaluator(loop, a_buf)(orig_loop_results);

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -407,7 +407,7 @@ Stmt* StmtClone::mutate(const Block* v) {
   for (Stmt* stmt : v->stmts()) {
     stmts.push_back(stmt->accept_mutator(this));
   }
-  return Block::make(stmts);
+  return new Block(stmts);
 }
 
 Stmt* StmtClone::mutate(const Store* v) {

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -420,7 +420,7 @@ Stmt* StmtClone::mutate(const Cond* v) {
   return new Cond(v->condition(), true_new, false_new);
 }
 
-Stmt* clone(Stmt* s) {
+Stmt* Stmt::clone(Stmt* s) {
   StmtClone clone_mutator;
   return s->accept_mutator(&clone_mutator);
 }

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -99,14 +99,6 @@ class TORCH_API IRMutator {
       std::vector<const Expr*>& params);
 };
 
-/*
- * Make a deep copy of the given statement.
- *
- * All statements used in children of S are cloned. Note that expressions and
- * variables are not deep-copied: it is not necessary since they are immutable.
- */
-TORCH_API Stmt* clone(Stmt* s);
-
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/schedule.cpp
+++ b/torch/csrc/jit/tensorexpr/schedule.cpp
@@ -575,7 +575,7 @@ void LoopNest::SplitWithTail(
   // x -> x.outer * inner.size + x.inner
   auto combined_index1 = i_outer * factor + i_inner;
 
-  Stmt* body_inner = Substitute(f->body(), {{f->var(), combined_index1}});
+  Stmt* body_inner = Substitute(Stmt::clone(f->body()), {{f->var(), combined_index1}});
 
   *inner = For::make(i_inner, 0, factor, body_inner);
   *outer = For::make(i_outer, 0, split_count, *inner);
@@ -588,7 +588,7 @@ void LoopNest::SplitWithTail(
     // x -> x.tail + outer.size * inner.size
     auto combined_index2 = i_tail + split_count * factor;
 
-    Stmt* body_tail = Substitute(f->body(), {{f->var(), combined_index2}});
+    Stmt* body_tail = Substitute(Stmt::clone(f->body()), {{f->var(), combined_index2}});
     *tail = For::make(i_tail, 0, tail_size, body_tail);
 
     p->append_stmt(*tail);
@@ -633,7 +633,7 @@ void LoopNest::SplitWithMask(Stmt* s, int factor, Stmt** outer, Stmt** inner) {
   // x -> x.outer * inner.size + x.inner
   auto combined_index = i_outer * factor + i_inner;
 
-  Stmt* body_inner = f->body();
+  Stmt* body_inner = Stmt::clone(f->body());
   // TODO: is it ok that we're doing it eagerly? In the other implementation we
   // are only materializing predicates at the last, lowering, step.
   if (tail_is_needed) {

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -73,6 +73,7 @@ class LetStmt : public StmtNode<LetStmt> {
   }
 
   static Stmt* make(const VarHandle& var, const ExprHandle& value, Stmt* body) {
+    CHECK(!body->get_parent());
     return new LetStmt(var.node(), value.node(), body);
   }
 
@@ -106,16 +107,19 @@ class Block : public StmtNode<Block> {
   }
 
   void append_stmt(Stmt* s) {
+    CHECK(!s->get_parent());
     stmts_.push_back(s);
     set_parent(s, this);
   }
   bool replace_stmt(Stmt* old_stmt, Stmt* new_stmt) {
+    CHECK(!new_stmt->get_parent());
     auto pos = std::find(stmts_.begin(), stmts_.end(), old_stmt);
     if (pos == stmts_.end()) {
       return false;
     }
     stmts_.insert(pos, new_stmt);
     stmts_.erase(pos);
+    set_parent(old_stmt, nullptr);
     set_parent(new_stmt, this);
     return true;
   }
@@ -125,6 +129,7 @@ class Block : public StmtNode<Block> {
 
   explicit Block(const std::vector<Stmt*>& stmts) {
     for (Stmt* s : stmts) {
+      CHECK(!s->get_parent());
       stmts_.push_back(s);
       set_parent(s, this);
     }
@@ -426,6 +431,7 @@ class For : public StmtNode<For> {
   For(const Var* var, const Expr* start, const Expr* stop, Stmt* body)
       : var_(var), start_(start), stop_(stop) {
     CHECK(var && start && stop && body);
+    CHECK(!body->get_parent());
     Block* b = dynamic_cast<Block*>(body);
     if (!b) {
       b = new Block({body});
@@ -441,6 +447,7 @@ class For : public StmtNode<For> {
       const LoopOptions& loop_options)
       : var_(var), start_(start), stop_(stop), loop_options_(loop_options) {
     CHECK(var && start && stop && body);
+    CHECK(!body->get_parent());
     Block* b = dynamic_cast<Block*>(body);
     if (!b) {
       b = new Block({body});

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -12,15 +12,24 @@ namespace tensorexpr {
 class Buffer;
 
 // The common base between all statement node.
-class Stmt : public KernelScopedObject {
+class TORCH_API Stmt : public KernelScopedObject {
  public:
   Stmt() {}
-  TORCH_API virtual void accept(IRVisitor* visitor) const = 0;
+  virtual void accept(IRVisitor* visitor) const = 0;
   virtual Stmt* accept_mutator(IRMutator* mutator) = 0;
 
   Stmt* get_parent() const {
     return parent_;
   }
+
+  /*
+   * Make a deep copy of the given statement.
+   *
+   * All statements used in children of the statement are cloned. Note that
+   * expressions and variables are not deep-copied: it is not necessary since
+   * they are immutable.
+   */
+  static Stmt* clone(Stmt* s);
 
  protected:
   static void set_parent(Stmt* s, Stmt* new_parent) {


### PR DESCRIPTION
There are three commits in this PR:
* Main one: Make sure that each statement is not used in more than one place.
* Make 'clone' a static method of 'Stmt'.
* Use 'new Block' instead of 'Block::make' in IRMutator for consistency with other methods.
