### PR TITLE
Do not constant-fold stateful functions (ie, rand)

### DIFF
--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -781,7 +781,6 @@ class TestFuser(JitTestCase):
         warmup_backward((hy + cy).sum())
 
     @unittest.skipIf(not RUN_CUDA, "fuser requires CUDA")
-    @unittest.skip("TE fuser broken")
     def test_rand_cuda(self):
         class M(torch.jit.ScriptModule):
             __constants__ = ['d']

--- a/torch/csrc/jit/tensorexpr/constant_folder.h
+++ b/torch/csrc/jit/tensorexpr/constant_folder.h
@@ -75,7 +75,7 @@ class ConstantFolder : public IRMutator {
       node = new Intrinsics(v->op_type(), new_params);
     }
 
-    if (!allConstant) {
+    if (!allConstant || !v->isPure()) {
       return node;
     }
 

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -712,6 +712,10 @@ class Intrinsics : public CallNode<Intrinsics> {
     CHECK_EQ(OpArgCount(op_type), nparams());
   }
 
+  bool isPure() const {
+    return op_type_ != kRand;
+  }
+
  private:
   TORCH_API static int OpArgCount(IntrinsicsOp op_type);
 


### PR DESCRIPTION
Test Plan: `python ./test/test_jit_fuser_te.py -k test_rand_cuda`